### PR TITLE
[Bugfix] Fix find_by_sql to work with un-accounted-for db columns

### DIFF
--- a/lib/dm-ar-finders.rb
+++ b/lib/dm-ar-finders.rb
@@ -126,7 +126,7 @@ module DataMapper
         used_keys = Set.new(properties.field_map)
         begin
           while reader.next!
-            records << reader.fields.zip(reader.values).select { |field, value| used_keys.include?(field) }
+            records << reader.fields.zip(reader.values).select { |field, value| used_keys.include?(field) }.to_h
           end
         ensure
           reader.close

--- a/lib/dm-ar-finders.rb
+++ b/lib/dm-ar-finders.rb
@@ -123,8 +123,7 @@ module DataMapper
 
       repository.adapter.send(:with_connection) do |connection|
         reader = connection.create_command(sql).execute_reader(*bind_values)
-        used_keys = Set.new(properties.field_map)
-        binding.pry
+        used_keys = Set.new(properties.field_map.keys)
         begin
           while reader.next!
             records << reader.fields.zip(reader.values).select { |field, value| used_keys.include?(field) }.to_h

--- a/lib/dm-ar-finders.rb
+++ b/lib/dm-ar-finders.rb
@@ -125,7 +125,7 @@ module DataMapper
         reader = connection.create_command(sql).execute_reader(*bind_values)
         begin
           while reader.next!
-            records << Hash[ reader.fields.zip(reader.values).slice(properties.field_map.keys) ]
+            records << Hash[ reader.fields.zip(reader.values).slice(*properties.field_map.keys) ]
           end
         ensure
           reader.close

--- a/lib/dm-ar-finders.rb
+++ b/lib/dm-ar-finders.rb
@@ -123,11 +123,9 @@ module DataMapper
 
       repository.adapter.send(:with_connection) do |connection|
         reader = connection.create_command(sql).execute_reader(*bind_values)
-        fields = properties.field_map.values_at(*reader.fields).compact
-
         begin
           while reader.next!
-            records << Hash[ fields.zip(reader.values) ]
+            records << Hash[ reader.fields.zip(reader.values).slice(properties.field_map.keys) ]
           end
         ensure
           reader.close

--- a/lib/dm-ar-finders.rb
+++ b/lib/dm-ar-finders.rb
@@ -123,7 +123,7 @@ module DataMapper
 
       repository.adapter.send(:with_connection) do |connection|
         reader = connection.create_command(sql).execute_reader(*bind_values)
-        used_keys = Set.new(properties.field_map.keys)
+        used_keys = Set.new(properties.field_map)
         begin
           while reader.next!
             records << reader.fields.zip(reader.values).select { |field, value| used_keys.include?(field) }

--- a/lib/dm-ar-finders.rb
+++ b/lib/dm-ar-finders.rb
@@ -123,9 +123,10 @@ module DataMapper
 
       repository.adapter.send(:with_connection) do |connection|
         reader = connection.create_command(sql).execute_reader(*bind_values)
+        used_keys = Set.new(properties.field_map.keys)
         begin
           while reader.next!
-            records << Hash[ reader.fields.zip(reader.values).slice(*properties.field_map.keys) ]
+            records << reader.fields.zip(reader.values).select { |field, value| used_keys.include?(field) }
           end
         ensure
           reader.close

--- a/lib/dm-ar-finders.rb
+++ b/lib/dm-ar-finders.rb
@@ -124,6 +124,7 @@ module DataMapper
       repository.adapter.send(:with_connection) do |connection|
         reader = connection.create_command(sql).execute_reader(*bind_values)
         used_keys = Set.new(properties.field_map)
+        binding.pry
         begin
           while reader.next!
             records << reader.fields.zip(reader.values).select { |field, value| used_keys.include?(field) }.to_h


### PR DESCRIPTION
Here we fix `find_by_sql` to work even if there are extra columns in the database not reflected in the Ruby schema.

Test plan:
Loaded the gem with current models and ran the command in the console.